### PR TITLE
Meson: Support Visual Studio builds

### DIFF
--- a/lgi/core.c
+++ b/lgi/core.c
@@ -517,8 +517,13 @@ static const struct luaL_Reg module_reg[] = {
 #define MODULE_NAME_FORMAT_VERSION "cyg%s-%d.dll"
 #define MODULE_NAME_FORMAT_PLAIN "cyg%s.dll"
 #elif defined(G_OS_WIN32)
+#ifdef _MSC_VER
+#define MODULE_NAME_FORMAT_VERSION "%s-%d.dll"
+#define MODULE_NAME_FORMAT_PLAIN "%s.dll"
+#else
 #define MODULE_NAME_FORMAT_VERSION "lib%s-%d.dll"
 #define MODULE_NAME_FORMAT_PLAIN "lib%s.dll"
+#endif
 #elif defined(__APPLE__)
 #define MODULE_NAME_FORMAT_VERSION "lib%s.%d.dylib"
 #define MODULE_NAME_FORMAT_PLAIN "lib%s.dylib"

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,15 @@ project('lgi', 'c',
   ],
 )
 
+cc = meson.get_compiler('c')
+test_c_args = []
+
+if cc.get_id() == 'msvc'
+  test_c_args += '-FImsvc_recommended_pragmas.h'
+endif
+
+add_project_arguments(cc.get_supported_arguments(test_c_args), language: 'c')
+
 lua_possible_names = [
   'lua',
   'lua5.3', 'lua53',

--- a/meson.build
+++ b/meson.build
@@ -51,14 +51,19 @@ lua_version_split = lua_dep.version().split('.')
 lua_abi_version = '@0@.@1@'.format(lua_version_split[0], lua_version_split[1])
 
 # These are defined by the luajit.pc and some distros lua.pc
-lua_cpath = lua_dep.get_pkgconfig_variable('INSTALL_CMOD',
-  define_variable: ['prefix', get_option('prefix')],
-  default: join_paths(get_option('libdir'), 'lua', lua_abi_version),
-)
-lua_path = lua_dep.get_pkgconfig_variable('INSTALL_LMOD',
-  define_variable: ['prefix', get_option('prefix')],
-  default: join_paths(get_option('datadir'), 'lua', lua_abi_version)
-)
+if lua_dep.type_name() == 'pkgconfig'
+  lua_cpath = lua_dep.get_pkgconfig_variable('INSTALL_CMOD',
+    define_variable: ['prefix', get_option('prefix')],
+    default: join_paths(get_option('libdir'), 'lua', lua_abi_version),
+  )
+  lua_path = lua_dep.get_pkgconfig_variable('INSTALL_LMOD',
+    define_variable: ['prefix', get_option('prefix')],
+    default: join_paths(get_option('datadir'), 'lua', lua_abi_version)
+  )
+else
+  lua_cpath = join_paths(get_option('libdir'), 'lua', lua_abi_version)
+  lua_path = join_paths(get_option('datadir'), 'lua', lua_abi_version)
+endif
 
 gi_dep = dependency('gobject-introspection-1.0')
 gi_datadir = gi_dep.get_pkgconfig_variable('gidatadir')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,9 +5,17 @@ regress_sources = [
   join_paths(gi_datadir, 'tests', 'regress.h'),
 ]
 
+test_c_args = []
+if cc.get_argument_syntax() == 'msvc'
+  test_c_args += '-D_GI_EXTERN=__declspec(dllexport)'
+endif
+if cc.get_id() != 'msvc'
+  test_c_args += '-w' # Not our warnings, ignore them
+endif
+
 libregress = shared_library('regress',
   sources: regress_sources,
-  c_args: '-w', # Not our warnings, ignore them
+  c_args: test_c_args,
   dependencies: [
     dependency('gio-2.0'),
     dependency('cairo-gobject'),

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -29,18 +29,21 @@ regress_gir = gnome.generate_gir(libregress,
   includes: ['Gio-2.0', 'cairo-1.0'],
 )
 
-dbus_run = find_program('dbus-run-session')
-test('regress', dbus_run,
-  args: [lua_prog.path(), files('test.lua')],
-  depends: regress_gir,
-  env: [
-    'LD_LIBRARY_PATH=' + meson.current_build_dir(),
-    'GI_TYPELIB_PATH=' + meson.current_build_dir(),
-    # Build dir is added for generated version.lua
-    'LUA_PATH=@0@/?.lua;@1@/?.lua'.format(meson.source_root(), meson.build_root()),
-    'LUA_CPATH=@0@/?.so;@0@/?.dll'.format(meson.build_root())
-  ]
-)
+dbus_run = find_program('dbus-run-session', required: host_machine.system() != 'windows')
+
+if dbus_run.found()
+  test('regress', dbus_run,
+    args: [lua_prog.path(), files('test.lua')],
+    depends: regress_gir,
+    env: [
+      'LD_LIBRARY_PATH=' + meson.current_build_dir(),
+      'GI_TYPELIB_PATH=' + meson.current_build_dir(),
+      # Build dir is added for generated version.lua
+      'LUA_PATH=@0@/?.lua;@1@/?.lua'.format(meson.source_root(), meson.build_root()),
+      'LUA_CPATH=@0@/?.so;@0@/?.dll'.format(meson.build_root())
+    ]
+  )
+endif
 
 test_c = executable('test_c', 'test_c.c', dependencies: lua_dep)
 test('multiple states', test_c)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -29,21 +29,23 @@ regress_gir = gnome.generate_gir(libregress,
   includes: ['Gio-2.0', 'cairo-1.0'],
 )
 
+test_env = [
+  'LD_LIBRARY_PATH=' + meson.current_build_dir(),
+  'GI_TYPELIB_PATH=' + meson.current_build_dir(),
+  # Build dir is added for generated version.lua
+  'LUA_PATH=@0@/?.lua;@1@/?.lua'.format(meson.source_root(), meson.build_root()),
+  'LUA_CPATH=@0@/?.so;@0@/?.dll'.format(meson.build_root())
+]
+
 dbus_run = find_program('dbus-run-session', required: host_machine.system() != 'windows')
 
 if dbus_run.found()
   test('regress', dbus_run,
     args: [lua_prog.path(), files('test.lua')],
     depends: regress_gir,
-    env: [
-      'LD_LIBRARY_PATH=' + meson.current_build_dir(),
-      'GI_TYPELIB_PATH=' + meson.current_build_dir(),
-      # Build dir is added for generated version.lua
-      'LUA_PATH=@0@/?.lua;@1@/?.lua'.format(meson.source_root(), meson.build_root()),
-      'LUA_CPATH=@0@/?.so;@0@/?.dll'.format(meson.build_root())
-    ]
+    env: test_env
   )
 endif
 
 test_c = executable('test_c', 'test_c.c', dependencies: lua_dep)
-test('multiple states', test_c)
+test('multiple states', test_c, env: test_env)


### PR DESCRIPTION
Hi,

This attempts to add support to the Meson build files to build with Visual Studio, by:

*  Avoiding configuration errors since Lua may have been found via CMake on Visual Studio-like builds instead of pkg-config by only trying to retrieve Lua pkg-config variables if it is really found via pkg-config.
* Force-include `msvc_recommended_pragmas.h` on Visual Studio builds, so that we can silence compiler warnings that we really don't need to bother about and make the ones that we should really worry about glaring to us.
* Don't prefix DLL names with `lib` in `core.c` for Visual Studio-like builds, since the Meson build files for Cairo do not prepend such prefixes, which is where this comes to play.
* Fix building `regress.dll` by making sure symbols are exported, so that its introspection files can be properly built.
* Skip running the `regress` test for now on Windows since `dbus-run-session` does not currently exist on Windows.
* Fix running the (other) tests(s) on Windows by setting the envvars that we have set for the `regress` tests as well.

With blessings, thank you!