### PR TITLE
Require meson 0.50.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('lgi', 'c',
   version: '0.9.2',
-  meson_version: '>= 0.46.0',
+  meson_version: '>= 0.50.0',
   default_options: [
     'warning_level=2',
     'buildtype=debugoptimized',


### PR DESCRIPTION
Without this, I get the following warnings:
```
WARNING: Project specifies a minimum meson_version '>= 0.46.0' but uses features which were added in newer versions:
 * 0.49.0: {'compiler.get_argument_syntax_method'}
 * 0.50.0: {'install arg in configure_file'}
```