### PR TITLE
Specify more library versions in sample code

### DIFF
--- a/samples/console.lua
+++ b/samples/console.lua
@@ -7,7 +7,7 @@ local Gio = lgi.Gio
 local Gtk = lgi.require('Gtk', '3.0')
 local Gdk = lgi.require('Gdk', '3.0')
 local Pango = lgi.Pango
-local GtkSource = lgi.GtkSource
+local GtkSource = lgi.require('GtkSource', '3.0')
 
 -- Creates new console instance.
 local function Console()

--- a/samples/goocanvas.lua
+++ b/samples/goocanvas.lua
@@ -1,5 +1,5 @@
 local lgi = require 'lgi'
-local Gtk = lgi.Gtk
+local Gtk = lgi.require('Gtk', '3.0')
 local Goo = lgi.GooCanvas
 
 local window = Gtk.Window {

--- a/samples/gstvideo.lua
+++ b/samples/gstvideo.lua
@@ -7,8 +7,8 @@
 
 local lgi  = require 'lgi'
 local GLib = lgi.GLib
-local Gtk  = lgi.Gtk
-local GdkX11 = lgi.GdkX11
+local Gtk  = lgi.require('Gtk', '3.0')
+local GdkX11 = lgi.require('GdkX11', '3.0')
 local Gst  = lgi.Gst
 if tonumber(Gst._version) >= 1.0 then
    local GstVideo = lgi.GstVideo

--- a/samples/gtk-demo/main.lua
+++ b/samples/gtk-demo/main.lua
@@ -33,7 +33,7 @@ local Gio = lgi.Gio
 local Gtk = lgi.require('Gtk', '3.0')
 local Pango = lgi.Pango
 local GdkPixbuf = lgi.GdkPixbuf
-local GtkSource = lgi.GtkSource
+local GtkSource = lgi.require('GtkSource', '3.0')
 
 -- Create package for the whole demo.
 local GtkDemo = lgi.package 'GtkDemo'

--- a/samples/gtkhello.lua
+++ b/samples/gtkhello.lua
@@ -7,7 +7,7 @@
 --
 
 local lgi = require 'lgi'
-local Gtk = lgi.require('Gtk')
+local Gtk = lgi.require('Gtk', '3.0')
 
 -- Create top level window with some properties and connect its 'destroy'
 -- signal to the event loop termination.


### PR DESCRIPTION
This is needed for systems that support both GTK 3 and GTK 4, otherwise,
'require' may try to pull in GTK 4, or other mutually incompatible
library versions.