### PR TITLE
Makefiles: do not override PKG_CONFIG variable if it is set

### DIFF
--- a/lgi/Makefile
+++ b/lgi/Makefile
@@ -11,7 +11,7 @@ LUA_VERSION=5.1
 LUA_LIBDIR = $(PREFIX)/lib/lua/$(LUA_VERSION)
 LUA_SHAREDIR = $(PREFIX)/share/lua/$(LUA_VERSION)
 
-PKG_CONFIG = pkg-config
+PKG_CONFIG ?= pkg-config
 GINAME = gobject-introspection-1.0
 PKGS = $(GINAME) gmodule-2.0 libffi
 VERSION_FILE = version.lua

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,7 +28,7 @@ endif
 PKGS = gio-2.0 cairo cairo-gobject gobject-introspection-1.0 gmodule-2.0 libffi
 LUA = lua
 LUA_LIB = -llua
-PKG_CONFIG = pkg-config
+PKG_CONFIG ?= pkg-config
 
 ifndef CFLAGS
 ifndef COPTFLAGS


### PR DESCRIPTION
in nixpkgs we set the PKG_CONFIG env var to the correct pkg-config and
i was getting 'pkg-config: No such file or directory'

https://makefiletutorial.com/