### PR TITLE
add an scm rockspec

### DIFF
--- a/lgi-scm-1.rockspec
+++ b/lgi-scm-1.rockspec
@@ -1,12 +1,12 @@
 package = 'lgi'
-version = '%VERSION%-1'
+version = 'scm-1'
 
 description = {
    summary = "Lua bindings to GObject libraries",
    detailed = [[
-	 Dynamic Lua binding to any library which is introspectable
-	 using gobject-introspection.  Allows using GObject-based libraries
-	 directly from Lua.
+    Dynamic Lua binding to any library which is introspectable
+    using gobject-introspection.  Allows using GObject-based libraries
+    directly from Lua.
    ]],
    license = 'MIT/X11',
    homepage = 'https://github.com/lgi-devs/lgi'
@@ -16,7 +16,6 @@ supported_platforms = { 'unix' }
 
 source = {
    url = 'git://github.com/lgi-devs/lgi.git',
-   tag = '%VERSION%'
 }
 
 dependencies = { 'lua >= 5.1' }


### PR DESCRIPTION
This adds a rockspec that can build from the master branch of the source repository. In this convention we check this rockspec in because it can be used universally. Generally versioned rockspecs you don't check in.

This will enable someone to build and install the latest version via LuaRocks with a command like:

```
luarocks install https://raw.githubusercontent.com/lgi-devs/lgi/master/lgi-scm-1.rockspec
```

After this change is accepted, we can also upload the scm rockspec to luarocks.org so we can use the "dev" manifest to also install the development version of this module