### PR TITLE
Export functions to append to the gi paths

### DIFF
--- a/lgi/gi.c
+++ b/lgi/gi.c
@@ -758,6 +758,22 @@ gi_isinfo (lua_State *L)
 }
 
 static int
+gi_add_ldpath (lua_State *L)
+{
+  const gchar *path = luaL_checkstring (L, 1);
+  g_irepository_prepend_library_path(path);
+  return 0;
+}
+
+static int
+gi_add_searchpath (lua_State *L)
+{
+  const gchar *path = luaL_checkstring (L, 1);
+  g_irepository_prepend_search_path(path);
+  return 0;
+}
+
+static int
 gi_index (lua_State *L)
 {
   if (lua_type (L, 2) == LUA_TLIGHTUSERDATA)
@@ -800,6 +816,8 @@ static const Reg gi_reg[] = {
 static const luaL_Reg gi_api_reg[] = {
   { "require", gi_require },
   { "isinfo", gi_isinfo },
+  { "add_ldpath", gi_add_ldpath },
+  { "add_searchpath", gi_add_searchpath },
   { NULL, NULL }
 };
 

--- a/lgi/init.lua
+++ b/lgi/init.lua
@@ -50,6 +50,9 @@ lgi.require = namespace.require
 -- Install 'lgi.package' method.
 lgi.package = require('lgi.package').ensure
 
+lgi.add_ldpath = core.gi.add_ldpath
+lgi.add_searchpath = core.gi.add_searchpath
+
 -- Add assert override, which accepts not only text message but any
 -- kind of error object.
 function lgi.assert(cond, ...)


### PR DESCRIPTION
A user might want to load gi objects not loaded global to the system. This exposes g_irepository_prepend_search_path and g_irepository_prepend_library_path which makes it easier to deal with local libraries.