### PR TITLE
Use $LUA_LIB in makefile on linux

### DIFF
--- a/lgi/Makefile
+++ b/lgi/Makefile
@@ -32,6 +32,7 @@ else
 CORE = corelgilua51.so
 LIBFLAG = -shared
 CCSHARED = -fPIC
+LIBS += $(LUA_LIB)
 endif
 endif
 


### PR DESCRIPTION
Is there any reason why LUA_LIB is not being used?

In my system lua does not get linked unless LUA_LIB is set causing corelgilua51.so to be totally broken.
Is the lua library supposed to get picked up at runtime? Otherwise how does it work for everyone else?

It may be because I have several lua versions, from 5.1 to 5.4 including luajit, all dependencies of something.

Besides fixing whatever is broken with multi-lua installations or in my system, this allows to specify the lua library you wan't like this: `make LUA_LIB="-lluajit-5.1"`