### PR TITLE
Fix Box hierarchy for GTK4

### DIFF
--- a/lgi/override/Gtk.lua
+++ b/lgi/override/Gtk.lua
@@ -219,8 +219,6 @@ if Gtk.Container then
    end
 end
 
--------------------------------- Gtk.Box overrides.
-Gtk.Box._container_add = Gtk.Box.append
 
 -------------------------------- Gtk.Builder overrides.
 Gtk.Builder._attribute = {}
@@ -633,6 +631,25 @@ Gtk._constant.PRINT_OUTPUT_URI = 'output-uri'
 
 -- Gtk-cairo integration helpers.
 cairo.Context._method.should_draw_window = Gtk.cairo_should_draw_window
+
+-------------------------------- Gtk-4 overrides
+
+
+if Gtk._version == '4.0' then
+
+   --- CONTAINER CLASSES
+   --- GTK4 Has removed the Container abstract class.
+   --- This means Boxes, Grids and other layout widgets 
+   --- Must now add children using their own specific methods.
+
+   --- Gtk.Box overrides
+
+   --- widgets on a the array part of the constructor of a Box
+   --- will be `append()`-ed
+   --- in order of appearance.
+   Gtk.Box._container_add = Gtk.Box.append
+
+end
 
 --------------------------------- Gtk-2 workarounds
 if Gtk._version == '2.0' then

--- a/lgi/override/Gtk.lua
+++ b/lgi/override/Gtk.lua
@@ -219,6 +219,9 @@ if Gtk.Container then
    end
 end
 
+-------------------------------- Gtk.Box overrides.
+Gtk.Box._container_add = Gtk.Box.append
+
 -------------------------------- Gtk.Builder overrides.
 Gtk.Builder._attribute = {}
 


### PR DESCRIPTION
## What is this supposed to fix?
Running the following code should result in a window with a button with a box, but only the window shows.
<details><summary><b><i>Snippet: GTK4 window with a Box</i></b></summary>
<p>

```
lgi = require 'lgi'
gtk = lgi.require('Gtk','4.0')

local app= gtk.Application{application_id = 'org.phicross.gtk4lua.intro'}
local handles = {application = app}

function app:on_startup()

end

function app:on_activate()
    handles.window = gtk.ApplicationWindow{ id = 'daWindow',
        application = self,
        title = "intro app.",
        default_width = 200,
        default_height = 200
    }

    handles.atop = gtk.Box{ orientation = gtk.Orientation.VERTICAL,
        id='daBox',
        gtk.Button {
            id = 'daButton',
            label = 'slap',
            on_clicked = function(self)
            print 'did you just slap me?'
            end
        } 
    }
    handles.window:set_child(handles.atop)

    print 'app ready.'
    print (handles.window.id)
--     print (handles.window.child.daButton.label)
--     print ('app window box child is '..handles.atop.child.name)

    handles.window:show()
end

app:run(arg)
```

</p>
</details> 

Using the GTK4 interactive debugger with `<CTRL>+<SHIFT>+I `, you can browse through the widget hierarchy, where the ApplicationWindow object will have a Box child, but the Box will not have anything in it.

Running the code with this fork's LGI will result in the hierarchy properly rendering, with a labeled button that says 'slap'.

## How was this fixed?
Just a single line on the GTK override file, where i set the underlying `_container_add` gobject method of the Box type to `Box.append()`.

## Are you seriously gonna publish just this naiive change to the main fork?
This pull request is for testing the waters. It is likely that more underlying code must be overriden for id navigation (e.g. `handles.atop.daBox.daButton.label='press me'`), child-on-child, other Container-like widgets that are no longer containers as of Gtk4, etc.
Is there demand for this library with Gtk4? are people gonna use lua constructors instead of the language-independent builder XML format? what kind of knowledge on lgi's internals do i need to accomodate for GTK4's API breakage? I would very much like a little catching-up on this matter.