### PR TITLE
Add mingw to supported platforms

### DIFF
--- a/lgi-scm-1.rockspec
+++ b/lgi-scm-1.rockspec
@@ -12,7 +12,7 @@ description = {
    homepage = 'https://github.com/lgi-devs/lgi'
 }
 
-supported_platforms = { 'unix' }
+supported_platforms = { 'unix', 'mingw' }
 
 source = {
    url = 'git://github.com/lgi-devs/lgi.git',

--- a/rockspec.in
+++ b/rockspec.in
@@ -12,7 +12,7 @@ description = {
    homepage = 'https://github.com/lgi-devs/lgi'
 }
 
-supported_platforms = { 'unix' }
+supported_platforms = { 'unix', 'mingw' }
 
 source = {
    url = 'git://github.com/lgi-devs/lgi.git',


### PR DESCRIPTION
Having installed `lgi` through luarocks in a MinGW 64-bit console and used it for various demos successfully I suggest to add `mingw` to the list of supported platforms in the rockspec, so Windows users can install the `lgi` rock without any modifications to the repo through luarocks.

When testing the various demos in `gtk-demo` all appeared to work except of the Images and Rotated Button demos. I have also tested some Xournal++ demos that use `lgi` and they worked too. 

Some more infos on how to install can be found in [this discussion](https://github.com/xournalpp/xournalpp/discussions/4522#discussioncomment-8789465). Note that for running `gtk-demo` you also have to install [`gtksourceview3`](https://packages.msys2.org/package/mingw-w64-x86_64-gtksourceview3?repo=mingw64).

