### PR TITLE
Wrap gi.require with assert in class.lua and ffi.lua

### DIFF
--- a/lgi/class.lua
+++ b/lgi/class.lua
@@ -20,7 +20,7 @@ local component = require 'lgi.component'
 local record = require 'lgi.record'
 local ffi = require 'lgi.ffi'
 local ti = ffi.types
-local GObject = gi.require 'GObject'
+local GObject = assert(gi.require('GObject'))
 
 -- Implementation of class and interface component loading.
 local class = {

--- a/lgi/ffi.lua
+++ b/lgi/ffi.lua
@@ -21,8 +21,8 @@ local record = require 'lgi.record'
 
 local ffi = {}
 
-local gobject = gi.require('GObject')
-local glib = gi.require('GLib')
+local gobject = assert(gi.require('GObject'))
+local glib = assert(gi.require('GLib'))
 
 -- Gather all basic types.  We have to 'steal' them from well-known
 -- declarations, because girepository API does not allow synthesizing


### PR DESCRIPTION
Fixes #71

Calling gi.require may not always succeed. If we do not wrap it in an `assert`, we will get confusing error messages.

For example, a failure in `lgi/ffi.lua` would look like:

    attempt to index local 'gobject' (a boolean value)

wrapping `gi.require` with `assert` instead would show a more informative message:

    Typelib file for namespace 'win32', version '1.0' not found

This change updates both `lgi/class.lua` and `lgi/ffi.lua` which appear to be the only two files in the codebase that do not wrap `gi.require` with an `assert`.

A practical example where this would have been useful is https://github.com/NixOS/nixpkgs/issues/139159#issuecomment-2156172046

I actually managed to figure out the issue with NixOS using this patch.

Thanks for developing and maintaining lgi!