### PR TITLE
fix: LuaJIT on Ubuntu CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [5.1.5, 5.2.4, 5.3.6, 5.4.3]
+        version: [5.1.5, 5.2.4, 5.3.6, 5.4.7]
 
     steps:
       - name: Build PUC-Rio Lua ${{ matrix.version }}
@@ -30,7 +30,7 @@ jobs:
         run: |
           cd "lua-${LUA_VERSION}"
           sudo make install
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install build dependencies
         run: source .github/install_deps.bash
       - name: Build lgi and the test suite
@@ -59,30 +59,27 @@ jobs:
     name: Test on LuaJIT
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        version: [2.0.5]
-
     steps:
-      - name: Build LuaJIT ${{ matrix.version }}
-        env:
-          LUAJIT_VERSION: ${{ matrix.version }}
-          LSAN_OPTIONS: exitcode=0
-        run: |
-          wget "https://luajit.org/download/LuaJIT-${LUAJIT_VERSION}.tar.gz"
-          tar xzvf "LuaJIT-${LUAJIT_VERSION}.tar.gz"
-          cd "LuaJIT-${LUAJIT_VERSION}"
-          make CC='gcc -g'
+      - name: Set environment variable to hold LuaJIT checkout directory
+        run: echo "LUAJIT_CHECKOUT=$(uuidgen)" >> "${{ github.env }}"
+      - name: Checkout LuaJIT from github mirror
+        uses: actions/checkout@v4
+        with:
+          repository: LuaJIT/LuaJIT
+          path: "${{ env.LUAJIT_CHECKOUT }}"
+      - name: Build LuaJIT
+        run: make -C "${{ env.LUAJIT_CHECKOUT }}" CC='gcc -g'
       - name: Install LuaJIT ${{ matrix.version }}
-        env:
-          LUAJIT_VERSION: ${{ matrix.version }}
         run: |
-          cd "LuaJIT-${LUAJIT_VERSION}"
-          sudo make install
+          sudo make -C "${{ env.LUAJIT_CHECKOUT }}" install
           sudo ln -frs /usr/local/bin/luajit-* /usr/local/bin/lua
           sudo ln -frs /usr/local/lib/libluajit-*.a /usr/local/lib/liblua.a
           sudo ln -frs /usr/local/include/luajit-*/* /usr/local/include/
-      - uses: actions/checkout@v2
+      - name: Set LUA_VERSION environment variable from LuaJIT's pkg-config file
+        run: |
+          lua_version=$(PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" pkg-config --variable=abiver luajit);
+          echo "LUA_VERSION=${lua_version}" >> "${{ github.env }}"
+      - uses: actions/checkout@v4
       - name: Install build dependencies
         run: source .github/install_deps.bash
       - name: Build lgi and the test suite
@@ -100,7 +97,6 @@ jobs:
         env:
           LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
           UBSAN_OPTIONS: print_stacktrace=1:report_error_type=1:halt_on_error=1:suppressions=${{ github.workspace }}/.github/ubsan.supp
-          LUA_VERSION: ${{ matrix.version }}
         run: |
           source .github/find_asan_ubsan.bash "lgi/corelgilua51.so"
           source .github/test_make_install.bash

--- a/.github/workflows/msvc-ci.yml
+++ b/.github/workflows/msvc-ci.yml
@@ -26,7 +26,7 @@ jobs:
     
     env:
       WINGTK_URL: https://github.com/wingtk/gvsbuild/releases/download/2024.10.0/GTK${{ matrix.gtk-major-version }}_Gvsbuild_2024.10.0_x64.zip
-      LUAINSTALLER_URL: https://github.com/luau-project/LuaInstaller/releases/download/v0.2.0.0/LuaInstaller.Console-v0.2.0.0-x64.zip
+      LUAINSTALLER_URL: https://github.com/luau-project/LuaInstaller/releases/download/v0.3.0.0/LuaInstaller.Console-v0.3.0.0-x64.zip
 
     steps:
 


### PR DESCRIPTION
## Description

### Ubuntu CI

* Fixed LuaJIT build on Ubuntu's CI: now, source code is fetched from the GitHub mirror. Quoting from [https://luajit.org/download.html](https://luajit.org/download.html)

> LuaJIT is only made available as source code from a git repository.

> LuaJIT uses rolling releases. There are no release tarballs available for download.

* Updated the latest Lua (PUC) version from 5.4.3 to 5.4.7;

### MSVC CI

* LuaInstaller was updated from v0.2.0.0 to v0.3.0.0, which addressed a potential bug that could happen in the future (you can read details at [v0.3.0.0 release](https://github.com/luau-project/LuaInstaller/releases/tag/v0.3.0.0)). 