### PR TITLE
bitflags: Return 0 if param is nil

### DIFF
--- a/lgi/enum.lua
+++ b/lgi/enum.lua
@@ -98,6 +98,8 @@ function enum.bitflags_mt:_new(param)
       return self[param]
    elseif type(param) == 'number' then
       return param
+   elseif not param then
+      return 0
    else
       local num = 0
       for key, value in pairs(param) do


### PR DESCRIPTION
This allows the user to opt out of passing flags into functions when there are none to specify. While libraries in statically typed languages expect users to pass in an explicit _NONE flag, Lua's ability to pass a variable number of parameters could easily be interpreted as explicitly not giving any flags when none are passed.

Fixes #329