### PR TITLE
Fix core_module on MacOS for GLIB >= 2.76

### DIFF
--- a/lgi/core.c
+++ b/lgi/core.c
@@ -556,10 +556,15 @@ core_module (lua_State *L)
 			    luaL_checkstring (L, 1));
 
 #if defined(__APPLE__)
+/* GLib 2.76 improved g_module_open() on MacOS, see
+   https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2950.  For
+   older GLib versions, use the previous workaround. */
+#if !GLIB_CHECK_VERSION(2, 76, 0)
   char *path = g_module_build_path (GOBJECT_INTROSPECTION_LIBDIR,
                                     name);
   g_free(name);
   name = path;
+#endif
 #endif
 
   /* Try to load the module. */


### PR DESCRIPTION
~This still needs some testing. Don't merge yet.~

This has been tested on MacOS Intel (on an old MacBook Pro) and on Macos ARM (M2 mini) through an automatic build of Xournal++ that bundles `lua-lgi`, see https://github.com/xournalpp/xournalpp/pull/6161/files, using GLib 2.82.


On MacOS ARM I have tested all gtk-demo examples after modifying `main.lua` such that it can be run as Xournal++ plugin. I had to replace the GtkSource.View by a Gtk.TextView, since we don't have GtkSourceView bundled in the right version for Xournal++. All gtk-demos worked except the Images demo, which crashes after a short while. It's the same on Windows and Linux. The UI-manager demo asks to press the Alt key, which is a bit unfortunate on MacOS. 

This PR basically reverts https://github.com/lgi-devs/lgi/commit/dab172c9769e161037e59bc34f9a665d33b89736 for GLib >= 2.76. I think the motivation for that commit was to workaround some problems with GLib < 2.76 on MacOS that were fixed in https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2950. That's why the change is only done for GLib >= 2.76