### PR TITLE
fix: install libreadline-dev on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,19 @@ jobs:
       matrix:
         version: [5.1.5, 5.2.4, 5.3.6, 5.4.7]
 
+    env:
+      LUA_VERSION: ${{ matrix.version }}
+    
     steps:
+      - name: Install Lua dependencies
+        run: sudo apt install -y libreadline-dev
       - name: Build PUC-Rio Lua ${{ matrix.version }}
-        env:
-          LUA_VERSION: ${{ matrix.version }}
         run: |
           wget "https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz"
           tar xzvf "lua-${LUA_VERSION}.tar.gz"
           cd "lua-${LUA_VERSION}"
-          make linux SYSLIBS="-Wl,-E -ldl -lreadline" SYSCFLAGS="-DLUA_USE_LINUX -ULUA_COMPAT_5_2 -DLUA_USE_APICHECK" CC='gcc -g'
+          make linux SYSLIBS="-Wl,-E -ldl -lreadline" SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_APICHECK" CC='gcc -g'
       - name: Install PUC-Rio Lua ${{ matrix.version }}
-        env:
-          LUA_VERSION: ${{ matrix.version }}
         run: |
           cd "lua-${LUA_VERSION}"
           sudo make install
@@ -46,7 +47,6 @@ jobs:
           xvfb-run -a sh -c 'LD_PRELOAD="${sanitizers}" make check'
       - name: Check that make install works
         env:
-          LUA_VERSION: ${{ matrix.version }}
           LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan.supp
           UBSAN_OPTIONS: print_stacktrace=1:report_error_type=1:halt_on_error=1:suppressions=${{ github.workspace }}/.github/ubsan.supp
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_puc:
     name: Test on PUC-Rio Lua
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -57,7 +57,7 @@ jobs:
 
   build_luajit:
     name: Test on LuaJIT
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Set environment variable to hold LuaJIT checkout directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,17 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  # Force software rendering on CI, because
+  # we were getting a CI error on Ubuntu 24.04 as follows:
+  #   MESA: error: ZINK: vkCreateInstance failed (VK_ERROR_INCOMPATIBLE_DRIVER))
+  # For more information, see https://github.com/lgi-devs/lgi/pull/332
+  LIBGL_ALWAYS_SOFTWARE: 1
+
 jobs:
   build_puc:
     name: Test on PUC-Rio Lua
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -57,7 +64,7 @@ jobs:
 
   build_luajit:
     name: Test on LuaJIT
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set environment variable to hold LuaJIT checkout directory

--- a/.github/workflows/msvc-ci.yml
+++ b/.github/workflows/msvc-ci.yml
@@ -26,7 +26,7 @@ jobs:
     
     env:
       WINGTK_URL: https://github.com/wingtk/gvsbuild/releases/download/2024.10.0/GTK${{ matrix.gtk-major-version }}_Gvsbuild_2024.10.0_x64.zip
-      LUAINSTALLER_URL: https://github.com/luau-project/LuaInstaller/releases/download/v0.3.0.0/LuaInstaller.Console-v0.3.0.0-x64.zip
+      LUAINSTALLER_URL: https://github.com/luau-project/LuaInstaller/releases/download/v0.5.0.0/LuaInstaller.Console-v0.5.0.0-x64.zip
 
     steps:
 


### PR DESCRIPTION
## Description

Recently, GitHub updated their Ubuntu runners labeled as ```ubuntu-latest``` to run under Ubuntu 24.04.

> [!NOTE]
> 
> Previously, ```ubuntu-latest``` ran on Ubuntu 22.04.

Due this change, the package ```libreadline-dev``` is not installed anymore by default, causing the current (Ubuntu) CI to fail while building Lua even for unrelated changes (notably [https://github.com/lgi-devs/lgi/pull/331](https://github.com/lgi-devs/lgi/pull/331)), because ```readline``` is missing in the system.

## Changes

* Added a step to install ```libreadline-dev``` before the build of Lua on (Ubuntu) CI;
* Minor edits in the (Ubuntu) CI regarding the ```LUA_VERSION``` environment variable;
* Updated MSVC CI to use the latest LuaInstaller version to install Lua ([Release notes](https://github.com/luau-project/LuaInstaller/releases/latest)).